### PR TITLE
feat(navbar): categorías dinámicas desde Vendure con dropdown

### DIFF
--- a/src/components/layout/navbar/navbar-collections/navbar-collections-client.tsx
+++ b/src/components/layout/navbar/navbar-collections/navbar-collections-client.tsx
@@ -1,28 +1,57 @@
+
 'use client';
 
-import { useRouter } from 'next/navigation';
-import { NavbarLink } from '../navbar-link';
-import { Button } from '@heroui/react';
+import Link from 'next/link';
+import {
+  NavigationMenuItem,
+  NavigationMenuTrigger,
+  NavigationMenuContent,
+  NavigationMenuLink,
+  navigationMenuTriggerStyle,
+} from '@/components/ui/navigation-menu';
 
-interface NavbarCollectionsClientProps {
+interface Collection {
+  id: string;
   name: string;
   slug: string;
 }
 
-export function NavbarCollectionsClient({ name, slug }: NavbarCollectionsClientProps) {
-  const router = useRouter();
+interface NavbarCollectionsClientProps {
+  collections: Collection[];
+}
 
-  const handleCollectionClick = () => {
-    // Redirect to search page with collection filter
-    router.push(`/search?collection=${slug}`);
-  };
+export function NavbarCollectionsClient({ collections }: NavbarCollectionsClientProps) {
+  const featured = collections.slice(0, 3);
+  const rest = collections.slice(3);
 
   return (
-    <button
-      onClick={handleCollectionClick}
-      className="group inline-flex h-9 w-max items-center justify-center rounded-md bg-background px-4 py-2 text-sm font-medium hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground disabled:pointer-events-none disabled:opacity-50 data-[state=open]:hover:bg-accent data-[state=open]:text-accent-foreground data-[state=open]:focus:bg-accent data-[state=open]:bg-accent/50 focus-visible:ring-ring/50 outline-none transition-[color,box-shadow] focus-visible:ring-[3px] focus-visible:outline-1"
-    >
-      {name}
-    </button>
+    <>
+      <NavigationMenuItem>
+        <NavigationMenuTrigger>Categorías</NavigationMenuTrigger>
+        <NavigationMenuContent>
+          <ul className="grid grid-cols-2 gap-1 p-3 w-[320px]">
+            {rest.map((collection) => (
+              <li key={collection.slug}>
+                <Link href={`/collection/${collection.slug}`} legacyBehavior passHref>
+                  <NavigationMenuLink className="block rounded-sm px-3 py-2 text-sm hover:bg-accent hover:text-accent-foreground transition-colors">
+                    {collection.name}
+                  </NavigationMenuLink>
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </NavigationMenuContent>
+      </NavigationMenuItem>
+
+      {featured.map((collection) => (
+        <NavigationMenuItem key={collection.slug}>
+          <Link href={`/collection/${collection.slug}`} legacyBehavior passHref>
+            <NavigationMenuLink className={navigationMenuTriggerStyle()}>
+              {collection.name}
+            </NavigationMenuLink>
+          </Link>
+        </NavigationMenuItem>
+      ))}
+    </>
   );
 }

--- a/src/components/layout/navbar/navbar-collections/navbar-collections.tsx
+++ b/src/components/layout/navbar/navbar-collections/navbar-collections.tsx
@@ -1,22 +1,13 @@
-import {
-  NavigationMenu,
-  NavigationMenuList,
-  NavigationMenuItem,
-} from '@/components/ui/navigation-menu';
+import { NavigationMenu, NavigationMenuList } from '@/components/ui/navigation-menu';
 import { NavbarCollectionsClient } from './navbar-collections-client';
 import { getNavbarCollections } from './navbar-collections.data';
 
 export async function NavbarCollections() {
   const collections = await getNavbarCollections();
-
   return (
     <NavigationMenu>
       <NavigationMenuList>
-        {collections.map((collection) => (
-          <NavigationMenuItem key={collection.slug}>
-            <NavbarCollectionsClient name={collection.name} slug={collection.slug} />
-          </NavigationMenuItem>
-        ))}
+        <NavbarCollectionsClient collections={collections} />
       </NavigationMenuList>
     </NavigationMenu>
   );

--- a/src/lib/vendure/shared/queries.ts
+++ b/src/lib/vendure/shared/queries.ts
@@ -4,7 +4,7 @@ import { ActiveCustomerFragment, ProductCardFragment } from './fragments';
 export const GetTopCollectionsQuery = graphql(`
     query GetTopCollections {
         collections(options: { filter: { parentId: { eq: "1" } }, 
-            take: 3 }) {
+            take: 50 }) {
             items {
                 id
                 name


### PR DESCRIPTION
Implementa navegación completa por categorías en el navbar, reemplazando las 3 categorías hardcodeadas por un sistema dinámico desde Vendure.
Cambios:

queries.ts: aumenta límite de collections de 3 a 50
navbar-collections.tsx: refactorizado para pasar array completo al cliente
navbar-collections-client.tsx: nuevo diseño con 3 links directos + dropdown "Categorías" con el resto, rutas corregidas a /collection/[slug]

Resultado:

Navbar muestra todas las categorías activas dinámicamente
Las primeras 3 se muestran como links directos
El resto se agrupa en dropdown para no saturar el navbar
Footer ya usaba la misma query, se beneficia automáticamente del cambio