### PR TITLE
fix(analytics): corregir Consent Mode - analytics_storage se actualiza antes de GTM

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -207,16 +207,30 @@ export default async function LocaleLayout({ children, params }: Props<"/[locale
               {`
                   window.dataLayer = window.dataLayer || [];
                   function gtag(){dataLayer.push(arguments);}
-                  
-                  const isLocalhost = typeof window !== \'undefined\' && (window.location.hostname === \'localhost\' || window.location.hostname === \'127.0.0.1\');
-                  
-                  gtag(\'consent\', \'default\', {
-                      ad_storage: isLocalhost ? \'granted\' : \'denied\',
-                      ad_user_data: isLocalhost ? \'granted\' : \'denied\',
-                      ad_personalization: isLocalhost ? \'granted\' : \'denied\',
-                      analytics_storage: isLocalhost ? \'granted\' : \'denied\',
+
+                  var isLocalhost = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+
+                  var storedConsent = null;
+                  try {
+                      storedConsent = localStorage.getItem('ecommer_cookie_consent');
+                  } catch (e) {}
+
+                  gtag('consent', 'default', {
+                      ad_storage: isLocalhost ? 'granted' : 'denied',
+                      ad_user_data: isLocalhost ? 'granted' : 'denied',
+                      ad_personalization: isLocalhost ? 'granted' : 'denied',
+                      analytics_storage: isLocalhost ? 'granted' : 'denied',
                       wait_for_update: 500
                   });
+
+                  if (storedConsent === 'granted') {
+                      gtag('consent', 'update', {
+                          ad_storage: 'granted',
+                          ad_user_data: 'granted',
+                          ad_personalization: 'granted',
+                          analytics_storage: 'granted'
+                      });
+                  }
               `}
           </Script>
           {gtmId && <GoogleTagManager gtmId={gtmId} />}

--- a/src/components/providers/consent-banner.tsx
+++ b/src/components/providers/consent-banner.tsx
@@ -26,8 +26,6 @@ export function ConsentBanner() {
         const stored = localStorage.getItem(CONSENT_STORAGE_KEY);
         if (!stored) {
             setVisible(true);
-        } else {
-            updateConsent(stored === 'granted');
         }
     }, []);
 


### PR DESCRIPTION
### Problema
GA4 recibía todos los hits con `gcs=G100` (consent denegado) aunque el usuario 
ya hubiera aceptado las cookies previamente. Esto causó que los datos de analytics 
dejaran de aparecer en los reportes desde el 9 de julio.

### Causa raíz
El `useEffect` en `ConsentBanner.tsx` que actualizaba el consent a `granted` 
se ejecutaba de forma asíncrona, DESPUÉS de que GTM ya había procesado los 
primeros hits con el estado `denied` por defecto.

### Fix
Se agregó un script inline en `layout.tsx` con `strategy="beforeInteractive"` 
que lee `localStorage('ecommer_cookie_consent')` de forma síncrona y, si es 
`'granted'`, dispara `gtag('consent', 'update')` ANTES de que cargue GTM.

Se simplificó `ConsentBanner.tsx` eliminando la lógica redundante del `useEffect`.

### Verificado
- `gcs=G111` (granted) en los hits de GA4 ✅
- Banner funciona correctamente en incógnito (sin consent previo) ✅
- GA4 Tiempo real muestra eventos correctamente ✅